### PR TITLE
Changed from catching all Exceptions to only catching IOExceptions.

### DIFF
--- a/src/main/clojure/clojure/core/strint.clj
+++ b/src/main/clojure/clojure/core/strint.clj
@@ -26,7 +26,7 @@
   (try
     (let [r (-> s java.io.StringReader. java.io.PushbackReader.)]
       [(read r) (slurp r)])
-    (catch Exception e))) ; this indicates an invalid form -- the head of s is just string data
+    (catch IOException e))) ; this indicates an invalid form -- the head of s is just string data
 
 (defn- interpolate
   "Yields a seq of Strings and read forms."


### PR DESCRIPTION
Changed from catching all exceptions to only catching the ones we are interested in. Because if any other error happens in there it will silently fail. Also it is easier to understand from the code what is being done and what is really happening.
